### PR TITLE
Changed NCBI Tax ID to string

### DIFF
--- a/specifications/model.md
+++ b/specifications/model.md
@@ -49,7 +49,7 @@ PyEED is a Python-encoded data model of an Enzyme Engineering Database. It suppo
   - Type: string
   - Description: Systematic name of the organism.
 - __ncbi_taxonomy_id__
-  - Type: integer
+  - Type: string
   - Description: NCBI Taxonomy ID to identify the organism
 
 ### Domain


### PR DESCRIPTION
NCBI Tax IDs also include characters and it makes sense to use the ```string``` type then. Sorry, that was my bad.